### PR TITLE
Adapted `extra_include=deliberation` that was always returning every …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,10 @@ Changelog
 - Added possibility to filter the `annexes endpoint` on any of the boolean
   attributes (`to_print`, `publishable`, `confidential`, `to_sign/signed`).
   [gbastien]
+- Adapted `extra_include=deliberation` that was always returning every variants
+  of deliberation (`deliberation/public_deliberation/public_deliberation_decided`),
+  now the `extra_include` value is the name of the variants we want to get.
+  [gbastien]
 
 1.0b1 (2021-02-03)
 ------------------

--- a/src/plonemeeting/restapi/serializer/item.py
+++ b/src/plonemeeting/restapi/serializer/item.py
@@ -42,12 +42,13 @@ class SerializeToJson(BaseATSerializeToJson):
                     (meeting, self.request), ISerializeToJson
                 )
                 result["extra_include_meeting"] = serializer(include_items=False)
-        if "deliberation" in extra_include:
+        delib_extra_includes = [ei for ei in extra_include
+                                if "deliberation" in extra_include]
+        if delib_extra_includes:
             # make the @@document-generation helper view available on self
             view = self.context.restrictedTraverse("document-generation")
             helper = view.get_generation_context_helper()
-            # the method helper.output_for_restapi manage what is returned by this endpoint
-            deliberation = helper.output_for_restapi()
+            deliberation = helper.deliberation_for_restapi(delib_extra_includes)
             result["extra_include_deliberation"] = deliberation
 
         return result

--- a/src/plonemeeting/restapi/tests/test_services_search.py
+++ b/src/plonemeeting/restapi/tests/test_services_search.py
@@ -134,8 +134,19 @@ class testServiceSearch(BaseTestCase):
         self.assertEqual(
             response.json()["items"][0]["extra_include_deliberation"],
             {
-                u"public_deliberation": u"<p>Motivation</p><p>Some decision.</p>",
                 u"deliberation": u"<p>Motivation</p><p>Some decision.</p>",
+            },
+        )
+        # extra_include several deliberation variants
+        endpoint_url = endpoint_url + "&extra_include=deliberation"
+        endpoint_url = endpoint_url + "&extra_include=public_deliberation"
+        endpoint_url = endpoint_url + "&extra_include=public_deliberation_decided"
+        response = self.api_session.get(endpoint_url)
+        self.assertEqual(
+            response.json()["items"][0]["extra_include_deliberation"],
+            {
+                u"deliberation": u"<p>Motivation</p><p>Some decision.</p>",
+                u"public_deliberation": u"<p>Motivation</p><p>Some decision.</p>",
                 u"public_deliberation_decided": u"<p>Motivation</p><p>Some decision.</p>",
             },
         )


### PR DESCRIPTION
…variants of deliberation (`deliberation/public_deliberation/public_deliberation_decided`), now the `extra_include` value is the name of the variants we want to get.

See #PM-3392