### PR TITLE
Added `test_restapi_search_items_extra_include_deliberation_images`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,9 @@ Changelog
 - Take into account the `extra_include_fullobjects` in the `MeetingItem` serializer.
   To handle this, it was necessary to implement a summary serializer for `Meeting`.
   [gbastien]
+- Added `test_restapi_search_items_extra_include_deliberation_images` showing
+  that images are received as base64 data value.
+  [gbastien]
 
 1.0b1 (2021-02-03)
 ------------------


### PR DESCRIPTION
Shows that images are received as base64 data value.

See #PM-3431