### PR TITLE
Fixed `PMLazyCatalogResultSerializer.__call__`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,10 @@ Changelog
   it is not searchable in the `portal_catalog` using the `@search` endpoint
   afterwards.
   [gbastien]
+- Fixed `PMLazyCatalogResultSerializer.__call__` to avoid an `UnboundLocalError`
+  or duplicates in results when the corresponding object does not exist anymore
+  for a brain or when a `KeyError` occured in call to serializer.
+  [gbastien]
 
 1.0rc1 (2021-08-17)
 -------------------

--- a/src/plonemeeting/restapi/serializer/catalog.py
+++ b/src/plonemeeting/restapi/serializer/catalog.py
@@ -39,6 +39,7 @@ class PMLazyCatalogResultSerializer(LazyCatalogResultSerializer):
 
         results = {}
         results["@id"] = batch.canonical_url
+        results["items_total"] = batch.items_total
         links = batch.links
         if links:
             results["batching"] = links
@@ -69,8 +70,5 @@ class PMLazyCatalogResultSerializer(LazyCatalogResultSerializer):
                 )()
 
             results["items"].append(result)
-
-        # compute items_total after results so we bypass not found brains
-        results["items_total"] = len(results["items"])
 
         return results

--- a/src/plonemeeting/restapi/tests/test_services_search.py
+++ b/src/plonemeeting/restapi/tests/test_services_search.py
@@ -692,13 +692,13 @@ class testServiceSearch(BaseTestCase):
         response = self.api_session.get(endpoint_url)
         self.assertEqual(response.status_code, 200, response.content)
         resp_json = response.json()
-        self.assertEqual(resp_json["items_total"], 2)
+        self.assertEqual(len(resp_json["items"]), 2)
         # with fullobjects, only 1 result
         endpoint_url += "&fullobjects"
         response = self.api_session.get(endpoint_url)
         self.assertEqual(response.status_code, 200, response.content)
         resp_json = response.json()
-        self.assertEqual(resp_json["items_total"], 1)
+        self.assertEqual(len(resp_json["items"]), 1)
 
 
 def test_suite():


### PR DESCRIPTION
to avoid an `UnboundLocalError` or duplicates in results when the corresponding object does not exist anymore for a brain or when a `KeyError` occured in call to serializer.

See #PM-3759