### PR TITLE
Fixed `BasePost._turn_ids_into_uids` to manage organizations outside `My organization`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,9 @@ Changelog
 1.0rc18 (unreleased)
 --------------------
 
-- Nothing changed yet.
-
+- Fixed `BasePost._turn_ids_into_uids` to manage organizations outside
+  `My organization` this is the case for field `MeetingItem.associatedGroups`.
+  [gbastien]
 
 1.0rc17 (2022-07-01)
 --------------------

--- a/src/plonemeeting/restapi/services/add.py
+++ b/src/plonemeeting/restapi/services/add.py
@@ -186,7 +186,10 @@ class BasePost(FolderPost):
         return []
 
     def _turn_ids_into_uids(self, data):
-        org_uids = get_organizations(only_selected=False, the_objects=False)
+        # this will also include organizations outside "My org"
+        org_uids = get_vocab(
+            self.cfg,
+            "Products.PloneMeeting.vocabularies.everyorganizationsvocabulary").by_token
 
         def _get_org_uid(field_name, field_value):
             """Get org UID as given field_value may be an UID or an id."""


### PR DESCRIPTION
This is the case for field `MeetingItem.associatedGroups`.

Added tests also to check that it is not possible to use orgs outside own org for other fields using orgs (groupsInCharge, optionalAdvisers).

See #PM-3933