### PR TITLE
Query with `in_name_of` and `uid` without `config_id` parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 1.0rc18 (unreleased)
 --------------------
 
+- Adapt `@get` endpoint with `in_name_of` paramater to allow either `UID` or `config_id`
+  [mpeeters]
 - Fixed `BasePost._turn_ids_into_uids` to manage organizations outside
   `My organization` this is the case for field `MeetingItem.associatedGroups`.
   [gbastien]

--- a/src/plonemeeting/restapi/tests/test_services_get.py
+++ b/src/plonemeeting/restapi/tests/test_services_get.py
@@ -155,16 +155,12 @@ class testServiceGetUid(BaseTestCase):
 
     def test_restapi_get_uid_in_name_of(self):
         """Check when using parameter in_name_of"""
+        # with an uid the element is correctly returned
         endpoint_url = "{0}/@get?UID={1}&in_name_of=pmCreator1".format(
             self.portal_url, self.item1_uid
         )
         response = self.api_session.get(endpoint_url)
-        # config_id is required when using in_name_of
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(
-            response.json(), {u"message": IN_NAME_OF_CONFIG_ID_ERROR, u"type": u"BadRequest"}
-        )
-        # with config_id the element is correctly returned
+        # with config_id in addition the element is correctly returned
         endpoint_url += "&config_id=%s" % self.meetingConfig.getId()
         response = self.api_session.get(endpoint_url)
         self.assertEqual(response.status_code, 200, response.content)

--- a/src/plonemeeting/restapi/utils.py
+++ b/src/plonemeeting/restapi/utils.py
@@ -20,7 +20,7 @@ from zope.component import queryMultiAdapter
 from zope.globalrequest import getRequest
 
 
-IN_NAME_OF_CONFIG_ID_ERROR = 'When using "in_name_of", the "config_id" parameter must be given!'
+IN_NAME_OF_CONFIG_ID_ERROR = 'When using "in_name_of", "config_id" or "uid" parameter must be given!'
 IN_NAME_OF_USER_NOT_FOUND = 'The in_name_of user "%s" was not found!'
 UID_NOT_ACCESSIBLE_ERROR = ('Element with UID "%s" was found but user "%s" can not access it!')
 UID_NOT_FOUND_ERROR = 'No element found with UID "%s"!'
@@ -30,8 +30,12 @@ def check_in_name_of(instance, data):
     """ """
     in_name_of = data.get("in_name_of", None)
     if in_name_of:
-        if not base_hasattr(instance, "cfg"):
+        if not base_hasattr(instance, "cfg") and not base_hasattr(instance, "uid"):
             raise BadRequest(IN_NAME_OF_CONFIG_ID_ERROR)
+        if not base_hasattr(instance, "cfg"):
+            tool = api.portal.get_tool("portal_plonemeeting")
+            obj = rest_uuid_to_object(instance.uid)
+            instance.cfg = tool.getMeetingConfig(obj)
         if not bool(may_access_config_endpoints(instance.cfg)):
             raise Unauthorized(IN_NAME_OF_UNAUTHORIZED % in_name_of)
         user = api.user.get(in_name_of)


### PR DESCRIPTION
Adapt code to allow query with `in_name_of` and `uid` without `config_id` parameter.

This is usefull for `imio.pm.wsclient` when we don't always have the config id depending on the context