### PR TITLE
Refactored `@item extra_include=linked_items` to filter results using a catalog query so parameters and functionnality is similar to other endpoints.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,12 @@ Changelog
   a key `field_name__choices` is added to the result with `token/title` of
   the selectable values.
   [gbastien]
+- Refactored `@item extra_include=linked_items` to filter results using a
+  catalog query so parameters and functionnality is similar to other endpoints.
+  Removed `utils.filter_data` that could be dangerous and build a catalog query.
+  Formalized convienence catalog index names substitution (passing parameter `type`
+  corresponds to index `portal_type` or `state` corresponds to `review_state`).
+  [gbastien]
 
 1.0rc17 (2022-07-01)
 --------------------

--- a/src/plonemeeting/restapi/config.py
+++ b/src/plonemeeting/restapi/config.py
@@ -8,3 +8,8 @@ IN_NAME_OF_UNAUTHORIZED = (
 )
 ANNEXES_FILTER_VALUES = [
     "to_print", "confidential", "publishable", "to_sign", "signed"]
+INDEX_CORRESPONDENCES = {
+    'getConfigId': 'config_id',
+    'review_state': 'state',
+    'portal_type': 'type',
+    'UID': 'uid'}

--- a/src/plonemeeting/restapi/services/search.py
+++ b/src/plonemeeting/restapi/services/search.py
@@ -5,6 +5,7 @@ from plone import api
 from plone.restapi.deserializer import boolean_value
 from plonemeeting.restapi.config import CONFIG_ID_ERROR
 from plonemeeting.restapi.config import CONFIG_ID_NOT_FOUND_ERROR
+from plonemeeting.restapi.config import INDEX_CORRESPONDENCES
 from plonemeeting.restapi.utils import check_in_name_of
 from zExceptions import BadRequest
 
@@ -36,15 +37,10 @@ class BaseSearchGet(SearchGet):
         query = {}
         form = self.request.form
 
-        # config_id is actually the getConfigId index
-        if "config_id" in form:
-            query["getConfigId"] = form["config_id"]
-        # convenience "state" is actually "review_state"
-        if "state" in form:
-            query["review_state"] = form["state"]
-        # convenience "uid" is actually "UID"
-        if "uid" in form:
-            query["UID"] = form["uid"]
+        # turn convenience indexes names into real index names
+        for real_index_name, easy_index_name in INDEX_CORRESPONDENCES.items():
+            if easy_index_name in form:
+                query[real_index_name] = form[easy_index_name]
 
         return query
 
@@ -67,12 +63,10 @@ class BaseSearchGet(SearchGet):
     def _clean_query(self, query):
         """Remove parameters that are not indexes names to avoid warnings like :
            WARNING plone.restapi.search.query No such index: 'extra_include'"""
-        query.pop("config_id", None)
         query.pop("extra_include", None)
         query.pop("in_name_of", None)
-        query.pop("state", None)
-        query.pop("type", None)
-        query.pop("uid", None)
+        for easy_index_name in INDEX_CORRESPONDENCES.values():
+            query.pop(easy_index_name, None)
 
 
 class PMSearchGet(BaseSearchGet):

--- a/src/plonemeeting/restapi/tests/test_services_get.py
+++ b/src/plonemeeting/restapi/tests/test_services_get.py
@@ -314,8 +314,9 @@ class testServiceGetUid(BaseTestCase):
         self.assertEqual(
             [linked_item['UID'] for linked_item in json["extra_include_linked_items"]],
             [new_item_uid, cfg2_item_uid])
-        # we may filter values, for example get only the cfg2 item
-        filter_endpoint_url = endpoint_url + "&extra_include_linked_items_filter=portal_type|{0}".format(
+        # we may filter values by providing some catalog indexes
+        # for example get only the cfg2 item, we can use real index name or easy name
+        filter_endpoint_url = endpoint_url + "&extra_include_linked_items_type={0}".format(
             cfg2.getItemTypeName())
         response = self.api_session.get(filter_endpoint_url)
         json = response.json()
@@ -323,8 +324,8 @@ class testServiceGetUid(BaseTestCase):
         self.assertEqual(
             [linked_item['UID'] for linked_item in json["extra_include_linked_items"]],
             [cfg2_item_uid])
-        # several filters, filter may be a callable method, here "query_state"
-        filter_endpoint_url = filter_endpoint_url + "&extra_include_linked_items_filter=query_state|{0}".format(
+        # several filters
+        filter_endpoint_url = filter_endpoint_url + "&extra_include_linked_items_review_state={0}".format(
             cfg2_item.query_state())
         response = self.api_session.get(filter_endpoint_url)
         json = response.json()


### PR DESCRIPTION
Removed `utils.filter_data` that could be dangerous and build a catalog query. Formalized convenience catalog index names substitution (passing parameter `type` corresponds to index `portal_type` or `state` corresponds to `review_state`).

See #PM-3916