### PR TITLE
Adapted code as `MeetingConfig.useGroupsAsCategories` was removed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,8 +13,9 @@ Changelog
 - Added `test_restapi_add_item_manually_linked_items` to check that it is possible
   to create items and use the `MeetingItem.manuallyLinkedItems` functionnality.
   [gbastien]
-- Make sure it is not possible to create an item with a category
-  if categories are not enabled. This is a temporary fix until PM-1008 is fixed.
+- Adapted code as `MeetingConfig.useGroupsAsCategories` was removed.
+  Field `MeetingItem.category` is an optional field managed by
+  `MeetingConfig.usedItemAttributes` as any other optional fields now.
   [gbastien]
 
 1.0rc18 (2022-08-26)

--- a/src/plonemeeting/restapi/services/add.py
+++ b/src/plonemeeting/restapi/services/add.py
@@ -274,18 +274,11 @@ class ItemPost(BasePost):
 
     @property
     def _optional_fields(self):
-        # XXX manage 'category' manually until
-        # https://support.imio.be/browse/PM-1008 is fixed
-        return self.cfg.listUsedItemAttributes() + ('category', )
+        return self.cfg.listUsedItemAttributes()
 
     @property
     def _active_fields(self):
-        # XXX manage 'category' manually until
-        # https://support.imio.be/browse/PM-1008 is fixed
-        used_item_attrs = self.cfg.getUsedItemAttributes()
-        if not self.cfg.getUseGroupsAsCategories():
-            used_item_attrs += ('category', )
-        return used_item_attrs
+        return self.cfg.getUsedItemAttributes()
 
     def _wf_transition_additional_warning(self, tr):
         warning_message = ""

--- a/src/plonemeeting/restapi/tests/test_services_add.py
+++ b/src/plonemeeting/restapi/tests/test_services_add.py
@@ -104,7 +104,7 @@ class testServiceAdd(BaseTestCase):
     def test_restapi_add_item_optional_fields(self):
         """When creating an item, given optional fields must be enabled in config."""
         cfg = self.meetingConfig
-        self.assertTrue(cfg.getUseGroupsAsCategories())
+        self.assertFalse("category" in cfg.getUsedItemAttributes())
         self.assertFalse("notes" in cfg.getUsedItemAttributes())
         self.changeUser("pmManager")
         endpoint_url = "{0}/@item".format(self.portal_url)
@@ -122,7 +122,7 @@ class testServiceAdd(BaseTestCase):
             response.json(),
             {u"message": OPTIONAL_FIELD_ERROR % "category", u"type": u"BadRequest"}
         )
-        cfg.setUseGroupsAsCategories(False)
+        self._enableField('category')
         transaction.commit()
         response = self.api_session.post(endpoint_url, json=json)
         transaction.begin()
@@ -148,7 +148,7 @@ class testServiceAdd(BaseTestCase):
            is added instead raising an error."""
         cfg = self.meetingConfig
         self.assertFalse("notes" in cfg.getUsedItemAttributes())
-        self.assertTrue(cfg.getUseGroupsAsCategories())
+        self.assertFalse("category" in cfg.getUsedItemAttributes())
         self.changeUser("pmManager")
         endpoint_url = "{0}/@item".format(self.portal_url)
         json = {
@@ -387,7 +387,7 @@ class testServiceAdd(BaseTestCase):
         """When creating an item, it is possible to define
            a list of fields to bypass validation for if it is empty."""
         cfg = self.meetingConfig
-        cfg.setUseGroupsAsCategories(False)
+        self._enableField('category')
         self._enableField("classifier")
         transaction.commit()
         self.changeUser("pmManager")

--- a/src/plonemeeting/restapi/tests/test_services_get.py
+++ b/src/plonemeeting/restapi/tests/test_services_get.py
@@ -25,7 +25,7 @@ class testServiceGetUid(BaseTestCase):
         super(testServiceGetUid, self).setUp()
         # especially necessary for branch 4.1.x where proposingGroup/category
         # was mixed and MeetingItem.getCategory would return the proposingGroup or the category
-        self.meetingConfig.setUseGroupsAsCategories(False)
+        self._enableField('category')
         self.changeUser("pmManager")
         self.item1 = self.create(
             "MeetingItem",

--- a/src/plonemeeting/restapi/tests/test_services_meetingconfig.py
+++ b/src/plonemeeting/restapi/tests/test_services_meetingconfig.py
@@ -83,7 +83,7 @@ class testServiceConfig(BaseTestCase):
         """@config"""
         # cfg2 uses disabled categories
         cfg = self.meetingConfig2
-        cfg.setUseGroupsAsCategories(False)
+        self._enableField('category')
         cfg_id = cfg.getId()
         transaction.commit()
         # categories
@@ -227,8 +227,7 @@ class testServiceConfig(BaseTestCase):
         """@config extra_include_fullobjects"""
         cfg = self.meetingConfig
         cfg_id = cfg.getId()
-        self._enableField('groupsInCharge')
-        cfg.setUseGroupsAsCategories(False)
+        self._enableField(('category', 'groupsInCharge'))
         cfg_id = cfg.getId()
         transaction.commit()
         endpoint_url_pattern = "{0}/@config?config_id={1}&extra_include={2}" \

--- a/src/plonemeeting/restapi/tests/test_services_search.py
+++ b/src/plonemeeting/restapi/tests/test_services_search.py
@@ -123,10 +123,8 @@ class testServiceSearch(BaseTestCase):
     def test_restapi_search_items_extra_include(self):
         """@search may receive an extra_include parameter"""
         transaction.begin()
-        cfg = self.meetingConfig
         self.changeUser("pmManager")
-        cfg.setUseGroupsAsCategories(False)
-        self._enableField("groupsInCharge")
+        self._enableField(("category", "groupsInCharge"))
         self.getMeetingFolder()
         meeting = self.create("Meeting", date=datetime(2020, 6, 8, 8, 0))
         item = self.create("MeetingItem",
@@ -268,9 +266,8 @@ class testServiceSearch(BaseTestCase):
     def test_restapi_search_items_extra_include_deliberation_images(self):
         """When asking for "deliberation" values, images are data base64 values"""
         transaction.begin()
-        cfg = self.meetingConfig
         self.changeUser("pmManager")
-        cfg.setUseGroupsAsCategories(False)
+        self._enableField('category')
         self.getMeetingFolder()
         item = self.create("MeetingItem")
         item.setMotivation("<p>Motivation</p>")
@@ -659,8 +656,7 @@ class testServiceSearch(BaseTestCase):
            - extra_include_category_fullobjects;
            - extra_include_category_include_base_data=false.
         """
-        cfg = self.meetingConfig
-        cfg.setUseGroupsAsCategories(False)
+        self._enableField('category')
         # create 2 items
         self.changeUser("pmManager")
         self.create("MeetingItem")
@@ -691,8 +687,7 @@ class testServiceSearch(BaseTestCase):
            - without fullobjects, the metadata catalog is used;
            - with fullobjects, then it is used to select the fields we want.
         """
-        cfg = self.meetingConfig
-        cfg.setUseGroupsAsCategories(False)
+        self._enableField('category')
         # create 2 items
         self.changeUser("pmManager")
         self.create("MeetingItem")


### PR DESCRIPTION
 Field `MeetingItem.category` is an optional field managed by `MeetingConfig.usedItemAttributes` as any other optional fields now.

See #PM-1008